### PR TITLE
Feat : 현재 사용자 멤버 권한 확인 Guard 구현

### DIFF
--- a/src/auth/guards/current-user-member-auth.guard.ts
+++ b/src/auth/guards/current-user-member-auth.guard.ts
@@ -8,11 +8,14 @@ import { MESSAGES } from 'src/constants/message.constant';
 import { MemberService } from 'src/member/member.service';
 
 @Injectable()
-export class MemberGuard implements CanActivate {
+export class CurrentUserMemberGuard implements CanActivate {
   constructor(private readonly memberservice: MemberService) {}
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
-    const { userId, boardId } = request.body;
+
+    const userId = request.user?.id;
+    let { boardId } = request.body;
+    if (request?.query?.boardId) boardId = request.query.boardId;
 
     if (!userId) {
       throw new NotFoundException(MESSAGES.AUTH.COMMON.MEMBER.NO_USER);

--- a/src/constants/message.constant.ts
+++ b/src/constants/message.constant.ts
@@ -37,6 +37,10 @@ export const MESSAGES = {
         INVALID: '인증 정보가 유효하지 않습니다.',
         DISCARDED_TOKEN: '폐기된 인증 정보입니다.',
       },
+      MEMBER: {
+        NO_USER: '멤버 식별에 필요한 사용자 정보를 입력해주세요.',
+        NO_BOARD: '멤버 식별에 필요한 보드 정보를 입력해주세요.',
+      },
     },
     SIGN_UP: {
       SECCEED: '회원가입에 성공했습니다.',

--- a/src/list/list.controller.ts
+++ b/src/list/list.controller.ts
@@ -15,11 +15,11 @@ import { UpdateOrderDto } from './dto/update-order.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { User } from 'src/user/entities/user.entity';
 import { UserInfo } from 'src/util/user-info.decorator';
-import { ApiTags } from '@nestjs/swagger';
-import { MemberGuard } from 'src/auth/guards/member-auth.guard';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { CurrentUserMemberGuard } from 'src/auth/guards/current-user-member-auth.guard';
 
-@UseGuards(JwtAuthGuard)
-@UseGuards(MemberGuard)
+@UseGuards(JwtAuthGuard, CurrentUserMemberGuard)
+@ApiBearerAuth()
 @ApiTags('list')
 @Controller('lists')
 export class ListController {


### PR DESCRIPTION
기존 memberGuard의 경우 내 정보가 아닌 상대방의 userId 를 받아와 member 확인하는 용도로 제작하였으나,
현재 사용자 본인이 Member 인지 사용하는 용도로 쓰여 권한 확인이 되지 않는 문제 발생함

**수정 사항**
1. 사용자 본인의 권한 확인 Guard 추가
2. 권한 확인에 필요한 userId, boardId 값 예외처리
3. controller @UseGuards 중첩 적용 문제 해결